### PR TITLE
Add CAS model

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .metals
 .vscode
 target
+test_run_dir

--- a/README.md
+++ b/README.md
@@ -60,8 +60,10 @@ Supply your config.json file and provide the generator its path:
 
 ```bash
 cd sdram_controller_gen
-sbt run $PATH_TO_CONFIG_FILE
+sbt -Xmx2048M run $PATH_TO_CONFIG_FILE
   ```
+
+It may be useful to set `SBT_OPTS` to `-Xmx2048M` so that you do not have to type it multiple times.
 
 ## To Do List ##
 

--- a/sdram_controller_gen/src/test/scala/mem.scala
+++ b/sdram_controller_gen/src/test/scala/mem.scala
@@ -33,7 +33,7 @@ class MemoryModelTest extends AnyFreeSpec with ChiselScalatestTester {
     val width = 8
     val banks = 2
     test(new MemModel(width, banks)).withAnnotations(Seq(WriteVcdAnnotation)) {dut =>
-      dut.io.addr.poke(32.U)
+      dut.io.addr.poke(16.U)
       dut.io.cmd.poke(MemCommand.mode)
       dut.clock.step()
       dut.io.bankSel.poke(0.U)
@@ -71,7 +71,7 @@ class MemoryModelTest extends AnyFreeSpec with ChiselScalatestTester {
     val width = 8
     val banks = 2
     test(new MemModel(width, banks)).withAnnotations(Seq(WriteVcdAnnotation)) {dut =>
-      dut.io.addr.poke(32.U)
+      dut.io.addr.poke(16.U)
       dut.io.cmd.poke(MemCommand.mode)
       dut.clock.step()
       dut.io.bankSel.poke(0.U)
@@ -102,7 +102,8 @@ class MemoryModelTest extends AnyFreeSpec with ChiselScalatestTester {
       dut.io.rwMask.poke(0xFF.U)
       dut.io.cmd.poke(MemCommand.read)
       dut.clock.step()
-      dut.io.rData.expect(0xA5.U)
+      // FIXME this one is broken, as it technically should be given how this works...
+      // dut.io.rData.expect(0xA5.U)
     }
   }
 
@@ -110,11 +111,9 @@ class MemoryModelTest extends AnyFreeSpec with ChiselScalatestTester {
     val width = 8
     val banks = 2
     test(new MemModel(width, banks)).withAnnotations(Seq(WriteVcdAnnotation)) {dut =>
-      dut.io.cmd.poke(MemCommand.mode)
-      dut.clock.step()
       dut.io.bankSel.poke(0.U)
       dut.io.rwMask.poke(((1 << width) - 1).U)
-      dut.io.addr.poke(545.U)
+      dut.io.addr.poke(529.U)
       dut.io.cmd.poke(MemCommand.mode)
       dut.io.commandEnable.poke(true.B)
       dut.clock.step()
@@ -146,10 +145,11 @@ class MemoryModelTest extends AnyFreeSpec with ChiselScalatestTester {
     test(new MemModel(width, banks)).withAnnotations(Seq(WriteVcdAnnotation)) {dut =>
       dut.io.bankSel.poke(0.U)
       dut.io.rwMask.poke(((1 << width) - 1).U)
-      dut.io.addr.poke(33.U)
+      dut.io.addr.poke(17.U)
       dut.io.cmd.poke(MemCommand.mode)
       dut.io.commandEnable.poke(true.B)
       dut.clock.step()
+      dut.io.addr.poke(1.U)
       dut.io.cmd.poke(MemCommand.active)
       dut.clock.step()
       // Write 0xAA,0x55 to bank 0, row 1, col 2-3
@@ -159,11 +159,49 @@ class MemoryModelTest extends AnyFreeSpec with ChiselScalatestTester {
       dut.io.writeEnable.poke(true.B)
       dut.clock.step()
       dut.io.wData.poke(0x55.U)
+      dut.io.cmd.poke(MemCommand.nop)
       dut.clock.step()
       // Read back in reverse order
       dut.io.writeEnable.poke(false.B)
       dut.io.addr.poke(3.U)
       dut.io.cmd.poke(MemCommand.read)
+      dut.clock.step()
+      dut.io.rData.expect(0x55.U)
+      dut.io.cmd.poke(MemCommand.nop)
+      dut.clock.step()
+      dut.io.rData.expect(0xAA.U)
+    }
+  }
+
+  "Test CAS latency" in {
+    val width = 8
+    val banks = 2
+    test(new MemModel(width, banks)).withAnnotations(Seq(WriteVcdAnnotation)) {dut =>
+      dut.io.bankSel.poke(0.U)
+      dut.io.rwMask.poke(((1 << width) - 1).U)
+      dut.io.addr.poke(17.U)
+      dut.io.cmd.poke(MemCommand.mode)
+      dut.io.commandEnable.poke(true.B)
+      dut.clock.step()
+      dut.io.addr.poke(1.U)
+      dut.io.cmd.poke(MemCommand.active)
+      dut.clock.step()
+      // Write 0xAA,0x55 to bank 0, row 1, col 2-3
+      dut.io.addr.poke(2.U)
+      dut.io.wData.poke((0xAA).U)
+      dut.io.cmd.poke(MemCommand.write)
+      dut.io.writeEnable.poke(true.B)
+      dut.clock.step()
+      dut.io.wData.poke(0x55.U)
+      dut.io.addr.poke(33.U)
+      dut.io.cmd.poke(MemCommand.mode)
+      dut.clock.step()
+      // Read back in reverse order
+      dut.io.writeEnable.poke(false.B)
+      dut.io.addr.poke(3.U)
+      dut.io.cmd.poke(MemCommand.read)
+      dut.clock.step()
+      dut.io.cmd.poke(MemCommand.nop)
       dut.clock.step()
       dut.io.rData.expect(0x55.U)
       dut.clock.step()

--- a/sdram_controller_gen/src/test/scala/mem.scala
+++ b/sdram_controller_gen/src/test/scala/mem.scala
@@ -33,6 +33,9 @@ class MemoryModelTest extends AnyFreeSpec with ChiselScalatestTester {
     val width = 8
     val banks = 2
     test(new MemModel(width, banks)).withAnnotations(Seq(WriteVcdAnnotation)) {dut =>
+      dut.io.addr.poke(32.U)
+      dut.io.cmd.poke(MemCommand.mode)
+      dut.clock.step()
       dut.io.bankSel.poke(0.U)
       dut.io.rwMask.poke(((1 << width) - 1).U)
       dut.io.addr.poke(1.U)
@@ -68,6 +71,9 @@ class MemoryModelTest extends AnyFreeSpec with ChiselScalatestTester {
     val width = 8
     val banks = 2
     test(new MemModel(width, banks)).withAnnotations(Seq(WriteVcdAnnotation)) {dut =>
+      dut.io.addr.poke(32.U)
+      dut.io.cmd.poke(MemCommand.mode)
+      dut.clock.step()
       dut.io.bankSel.poke(0.U)
       dut.io.rwMask.poke(0xFF.U)
       dut.io.addr.poke(1.U)
@@ -104,9 +110,11 @@ class MemoryModelTest extends AnyFreeSpec with ChiselScalatestTester {
     val width = 8
     val banks = 2
     test(new MemModel(width, banks)).withAnnotations(Seq(WriteVcdAnnotation)) {dut =>
+      dut.io.cmd.poke(MemCommand.mode)
+      dut.clock.step()
       dut.io.bankSel.poke(0.U)
       dut.io.rwMask.poke(((1 << width) - 1).U)
-      dut.io.addr.poke(513.U)
+      dut.io.addr.poke(545.U)
       dut.io.cmd.poke(MemCommand.mode)
       dut.io.commandEnable.poke(true.B)
       dut.clock.step()
@@ -126,6 +134,7 @@ class MemoryModelTest extends AnyFreeSpec with ChiselScalatestTester {
       dut.io.cmd.poke(MemCommand.read)
       dut.clock.step()
       dut.io.rData.expect(0x55.U)
+      dut.io.cmd.poke(MemCommand.nop)
       dut.clock.step()
       dut.io.rData.expect(0xAA.U)
     }
@@ -137,7 +146,7 @@ class MemoryModelTest extends AnyFreeSpec with ChiselScalatestTester {
     test(new MemModel(width, banks)).withAnnotations(Seq(WriteVcdAnnotation)) {dut =>
       dut.io.bankSel.poke(0.U)
       dut.io.rwMask.poke(((1 << width) - 1).U)
-      dut.io.addr.poke(1.U)
+      dut.io.addr.poke(33.U)
       dut.io.cmd.poke(MemCommand.mode)
       dut.io.commandEnable.poke(true.B)
       dut.clock.step()

--- a/sdram_controller_gen/src/test/scala/mem.scala
+++ b/sdram_controller_gen/src/test/scala/mem.scala
@@ -102,8 +102,7 @@ class MemoryModelTest extends AnyFreeSpec with ChiselScalatestTester {
       dut.io.rwMask.poke(0xFF.U)
       dut.io.cmd.poke(MemCommand.read)
       dut.clock.step()
-      // FIXME this one is broken, as it technically should be given how this works...
-      // dut.io.rData.expect(0xA5.U)
+      dut.io.rData.expect(0xA5.U)
     }
   }
 
@@ -113,7 +112,7 @@ class MemoryModelTest extends AnyFreeSpec with ChiselScalatestTester {
     test(new MemModel(width, banks)).withAnnotations(Seq(WriteVcdAnnotation)) {dut =>
       dut.io.bankSel.poke(0.U)
       dut.io.rwMask.poke(((1 << width) - 1).U)
-      dut.io.addr.poke(529.U)
+      dut.io.addr.poke(81.U)
       dut.io.cmd.poke(MemCommand.mode)
       dut.io.commandEnable.poke(true.B)
       dut.clock.step()


### PR DESCRIPTION
DANGER: If using burst, the data line will be held at the first address until NOP is issued for CAS - 1 cycles.
Technically undefined behavior with the original hardware but it will be annoying to program.

Also switches to a Bool SyncReadMem internally.