### PR TITLE
It's the the refresh command

### DIFF
--- a/sdram_controller_gen/src/main/scala/mem.scala
+++ b/sdram_controller_gen/src/main/scala/mem.scala
@@ -54,7 +54,7 @@ class MemModelCASEntry(addrWidth: Int, bankWidth: Int) extends Bundle {
   val bankSel = UInt(bankWidth.W)
 }
 
-class MemModel(width: Int, banks: Int, rowWidth: Int = 9, colWidth: Int = 6)
+class MemModel(width: Int, hz: Int, banks: Int, rowWidth: Int = 9, colWidth: Int = 6)
     extends Module {
   val bankWidth = log2Ceil(banks)
   require(colWidth < rowWidth)
@@ -163,26 +163,22 @@ class MemModel(width: Int, banks: Int, rowWidth: Int = 9, colWidth: Int = 6)
     }
   }
 
-  // TODO: Parameterize number of cycles needed to refresh
-  // Also make a separate counter that resets when refresh is low
-  // so we have to hold refresh for a certain number of cycles for it to be effective
-  // maybe? the first thing is probably sufficient honestly
-  val refreshCounter = RegInit(0.U(log2Ceil(2048).W))
+  // Need 2048 cycles of refresh every 64 ms
+  val refreshMax = (hz / 1000) * 64
+  val refreshPerCycle = refreshMax / 2048
+  val refreshCounter = RegInit(0.U(log2Ceil(refreshMax).W))
   io.debug.refresh := refreshCounter
   when(io.cmd === MemCommand.refresh && io.commandEnable) {
-    when(refreshCounter > 0.U) {
-      refreshCounter := refreshCounter - 1.U
+    when(refreshCounter > refreshPerCycle.U) {
+      refreshCounter := refreshCounter - refreshPerCycle.U
+    } .otherwise {
+      refreshCounter := 0.U
     }
-  }.elsewhen(refreshCounter >= 2048.U) {
-      // While it would be nice to actually do something here
-      // generating any kind of hardware that operates over any decently large section of memory
-      // would kill sbt. So we'll likely add something to start killing commands at this point
-    }
-    .otherwise {
-      refreshCounter := refreshCounter + 1.U
-    }
+  }.elsewhen(refreshCounter < (refreshMax - 1).U) {
+    refreshCounter := refreshCounter + 1.U
+  }
 
-  when(!io.commandEnable) {
+  when(!io.commandEnable || refreshCounter >= (refreshMax - 1).U) {
     // do nothing
   }.elsewhen(io.cmd === MemCommand.active) {
       // Only activate a bank row if it is valid

--- a/sdram_controller_gen/src/test/scala/mem.scala
+++ b/sdram_controller_gen/src/test/scala/mem.scala
@@ -31,7 +31,7 @@ class MemoryModelTest extends AnyFreeSpec with ChiselScalatestTester {
   "Test read and write; single cell, full mask" in {
     val width = 8
     val banks = 2
-    test(new MemModel(width, banks)).withAnnotations(Seq(WriteVcdAnnotation)) {
+    test(new MemModel(width, 2048, banks)).withAnnotations(Seq(WriteVcdAnnotation)) {
       dut =>
         dut.io.addr.poke(16.U)
         dut.io.cmd.poke(MemCommand.mode)
@@ -70,7 +70,7 @@ class MemoryModelTest extends AnyFreeSpec with ChiselScalatestTester {
   "Test read and write; single cell, lower nibble mask" in {
     val width = 8
     val banks = 2
-    test(new MemModel(width, banks)).withAnnotations(Seq(WriteVcdAnnotation)) {
+    test(new MemModel(width, 2048, banks)).withAnnotations(Seq(WriteVcdAnnotation)) {
       dut =>
         dut.io.addr.poke(16.U)
         dut.io.cmd.poke(MemCommand.mode)
@@ -110,7 +110,7 @@ class MemoryModelTest extends AnyFreeSpec with ChiselScalatestTester {
   "Test burst read, individual write" in {
     val width = 8
     val banks = 2
-    test(new MemModel(width, banks)).withAnnotations(Seq(WriteVcdAnnotation)) {
+    test(new MemModel(width, 2048, banks)).withAnnotations(Seq(WriteVcdAnnotation)) {
       dut =>
         dut.io.bankSel.poke(0.U)
         dut.io.rwMask.poke(((1 << width) - 1).U)
@@ -143,7 +143,7 @@ class MemoryModelTest extends AnyFreeSpec with ChiselScalatestTester {
   "Test burst read, burst write" in {
     val width = 8
     val banks = 2
-    test(new MemModel(width, banks)).withAnnotations(Seq(WriteVcdAnnotation)) {
+    test(new MemModel(width, 2048, banks)).withAnnotations(Seq(WriteVcdAnnotation)) {
       dut =>
         dut.io.bankSel.poke(0.U)
         dut.io.rwMask.poke(((1 << width) - 1).U)
@@ -178,7 +178,7 @@ class MemoryModelTest extends AnyFreeSpec with ChiselScalatestTester {
   "Test CAS latency" in {
     val width = 8
     val banks = 2
-    test(new MemModel(width, banks)).withAnnotations(Seq(WriteVcdAnnotation)) {
+    test(new MemModel(width, 2048, banks)).withAnnotations(Seq(WriteVcdAnnotation)) {
       dut =>
         dut.io.bankSel.poke(0.U)
         dut.io.rwMask.poke(((1 << width) - 1).U)

--- a/sdram_controller_gen/src/test/scala/mem.scala
+++ b/sdram_controller_gen/src/test/scala/mem.scala
@@ -10,13 +10,13 @@ import scala.concurrent.duration._
 class ShiftRegTest extends AnyFreeSpec with ChiselScalatestTester {
   "Test shift; fixed CAS" in {
     val slots = 2
-    test(new AdjustableShiftRegister(slots, Bool())) { dut =>
+    test(new AdjustableShiftRegister(slots, new MemModelCASEntry(1, 1))) { dut =>
       dut.io.shift.poke(slots.U)
       for (i <- 0 to slots) {
         dut.clock.step()
         dut.io.output.valid.expect(false.B)
       }
-      dut.io.input.bits.poke(true.B)
+      dut.io.input.bits.precharge.poke(true.B)
       dut.io.input.valid.poke(true.B)
       dut.clock.step()
       dut.io.input.valid.poke(false.B)
@@ -196,11 +196,13 @@ class MemoryModelTest extends AnyFreeSpec with ChiselScalatestTester {
         dut.io.writeEnable.poke(true.B)
         dut.clock.step()
         dut.io.wData.poke(0x55.U)
+        dut.io.cmd.poke(MemCommand.nop)
+        dut.clock.step()
         dut.io.addr.poke(33.U)
         dut.io.cmd.poke(MemCommand.mode)
+        dut.io.writeEnable.poke(false.B)
         dut.clock.step()
         // Read back in reverse order
-        dut.io.writeEnable.poke(false.B)
         dut.io.addr.poke(3.U)
         dut.io.cmd.poke(MemCommand.read)
         dut.clock.step()


### PR DESCRIPTION
The refresh command currently only preempts things if we're idle and have a pending refresh. Otherwise it will try to wait for an idle moment during row activation. There is definitely a more efficient (both in power and logic) way to do this, but this works for now.

~~A better way would be to use this counter to set a flag when we have an outstanding refresh, then increment it every cycles_per_refresh - 2. Even if we're occupied when the refresh is "supposed" to happen, this should be able to refresh the entire RAM without exceeding 64ms for any block.~~ Implemented.